### PR TITLE
fix(calendar): correct RRULE times in local TZ; UI + calendar-only crawl

### DIFF
--- a/crawlers/calendar_crawler.py
+++ b/crawlers/calendar_crawler.py
@@ -143,30 +143,36 @@ def _parse_event(component, now: datetime, cutoff: datetime, calendar_name: str 
         dtstart = component.get("DTSTART")
         if dtstart is None:
             return []
-        start = dtstart.dt
-
-        # Convert date-only events to datetime
-        if not isinstance(start, datetime):
-            start = datetime(start.year, start.month, start.day, tzinfo=timezone.utc)
-        start = _to_utc(start)
+        # Keep DTSTART/DTEND as icalendar parsed them (often TZID-aware) for RRULE.
+        # Converting DTSTART to UTC *before* rrulestr() makes WEEKLY/BYDAY expand in UTC,
+        # which shifts wall-clock times across DST (e.g. 9am America/Los_Angeles becomes wrong).
+        start_raw = dtstart.dt
+        if not isinstance(start_raw, datetime):
+            start_raw = datetime(
+                start_raw.year, start_raw.month, start_raw.day, tzinfo=timezone.utc
+            )
 
         dtend = component.get("DTEND")
-        end = None
+        end_raw: Optional[datetime] = None
         if dtend:
-            end = dtend.dt
-            if not isinstance(end, datetime):
-                end = datetime(end.year, end.month, end.day, tzinfo=timezone.utc)
-            end = _to_utc(end)
+            end_raw = dtend.dt
+            if not isinstance(end_raw, datetime):
+                end_raw = datetime(
+                    end_raw.year, end_raw.month, end_raw.day, tzinfo=timezone.utc
+                )
+
+        start_utc = _to_utc(start_raw)
+        end_utc = _to_utc(end_raw) if end_raw is not None else None
 
         title = str(component.get("SUMMARY") or "").strip()
         location = str(component.get("LOCATION") or "").strip()
         description = str(component.get("DESCRIPTION") or "").strip()
         rrule = component.get("RRULE")
 
-        # Duration (for recurring instances)
+        # Wall-duration between DTSTART and DTEND (stable for recurring instances).
         duration = None
-        if end and isinstance(end, datetime):
-            duration = end - start
+        if end_raw is not None:
+            duration = _to_utc(end_raw) - _to_utc(start_raw)
 
         base = {
             "title": title,
@@ -177,14 +183,14 @@ def _parse_event(component, now: datetime, cutoff: datetime, calendar_name: str 
 
         # Non-recurring
         if not rrule:
-            if start < now or start > cutoff:
+            if start_utc < now or start_utc > cutoff:
                 return []
             return [{
                 **base,
-                "start": start.isoformat(),
-                "end": end.isoformat() if end else None,
+                "start": start_utc.isoformat(),
+                "end": end_utc.isoformat() if end_utc else None,
                 "recurring": False,
-                "_start_ts": start.timestamp(),
+                "_start_ts": start_utc.timestamp(),
             }]
 
         # Recurring: expand occurrences within window
@@ -192,14 +198,14 @@ def _parse_event(component, now: datetime, cutoff: datetime, calendar_name: str 
             from dateutil.rrule import rrulestr
         except Exception:
             # python-dateutil is in requirements; if missing, fall back to including only DTSTART
-            if start < now or start > cutoff:
+            if start_utc < now or start_utc > cutoff:
                 return []
             return [{
                 **base,
-                "start": start.isoformat(),
-                "end": end.isoformat() if end else None,
+                "start": start_utc.isoformat(),
+                "end": end_utc.isoformat() if end_utc else None,
                 "recurring": True,
-                "_start_ts": start.timestamp(),
+                "_start_ts": start_utc.timestamp(),
             }]
 
         # rrulestr needs the RRULE line, not just the value
@@ -227,7 +233,7 @@ def _parse_event(component, now: datetime, cutoff: datetime, calendar_name: str 
 
         occs: list[dict] = []
         if rule_text:
-            rule = rrulestr(rule_text, dtstart=start)
+            rule = rrulestr(rule_text, dtstart=start_raw)
             # between() is inclusive; we want events starting in [now, cutoff]
             for occ in rule.between(now, cutoff, inc=True):
                 occ_utc = _to_utc(occ)

--- a/data/iceberg/events.json
+++ b/data/iceberg/events.json
@@ -1,6 +1,6 @@
 {
   "project_id": "iceberg",
-  "generated_at": "2026-03-30T07:17:11.301457+00:00",
+  "generated_at": "2026-03-30T23:21:34.690744+00:00",
   "calendar_urls": [
     {
       "name": "Iceberg Dev Events",
@@ -12,15 +12,6 @@
     }
   ],
   "events": [
-    {
-      "title": "Iceberg Index Support Sync",
-      "location": "",
-      "description": "<br>Design doc: <a href=\"https://docs.google.com/document/d/1N6a2IOzC6Qsqv7NBqHKesees4N6WF49YUSIX2FrF7S0/edit?tab=t.0#heading=h.hs6r9d26w1y2\" class=\"pastedDriveLink-0\">https://docs.google.com/document/d/1N6a2IOzC6Qsqv7NBqHKesees4N6WF49YUSIX2FrF7S0/edit?tab=t.0#heading=h.hs6r9d26w1y2</a>\n\nJoin with Google Meet: https://meet.google.com/njx-cnib-jyd\n\nLearn more about Meet at: https://support.google.com/a/users/answer/9282720",
-      "calendar": "Iceberg Dev Events",
-      "start": "2026-03-30T17:00:00+00:00",
-      "end": "2026-03-30T18:00:00+00:00",
-      "recurring": true
-    },
     {
       "title": "Iceberg python library sync",
       "location": "",
@@ -35,8 +26,8 @@
       "location": "",
       "description": "<br>Agenda and notes: <a href=\"https://docs.google.com/document/d/1iGNydKY7XT1N5Nz056vDPM0P8v0MFymGqNtOlUGUp-c/edit?tab=t.0\" class=\"pastedDriveLink-0\">https://docs.google.com/document/d/1iGNydKY7XT1N5Nz056vDPM0P8v0MFymGqNtOlUGUp-c/edit?tab=t.0</a>\n\nJoin with Google Meet: https://meet.google.com/gwy-jxos-jif\n\nLearn more about Meet at: https://support.google.com/a/users/answer/9282720",
       "calendar": "Iceberg Dev Events",
-      "start": "2026-03-31T17:00:00+00:00",
-      "end": "2026-03-31T18:00:00+00:00",
+      "start": "2026-03-31T16:00:00+00:00",
+      "end": "2026-03-31T17:00:00+00:00",
       "recurring": true
     },
     {
@@ -62,8 +53,8 @@
       "location": "",
       "description": "<a href=\"https://docs.google.com/document/d/1UnhldHhe3Grz8JBngwXPA6ZZord1xMedY5ukEhZYF-A/edit?tab=t.4lz4t8og6hk2\" class=\"pastedDriveLink-0\">Iceberg Materialized View Spec</a>\n\nJoin with Google Meet: https://meet.google.com/uvs-jznm-ztm\n\nLearn more about Meet at: https://support.google.com/a/users/answer/9282720",
       "calendar": "Iceberg Dev Events",
-      "start": "2026-04-02T17:00:00+00:00",
-      "end": "2026-04-02T18:00:00+00:00",
+      "start": "2026-04-02T16:00:00+00:00",
+      "end": "2026-04-02T17:00:00+00:00",
       "recurring": true
     },
     {
@@ -82,15 +73,15 @@
       "calendar": "Iceberg Dev Events",
       "start": "2026-04-08T16:00:00+00:00",
       "end": "2026-04-08T17:00:00+00:00",
-      "recurring": false
+      "recurring": true
     },
     {
       "title": "Iceberg Index Support Sync",
       "location": "",
       "description": "<br>Design doc: <a href=\"https://docs.google.com/document/d/1N6a2IOzC6Qsqv7NBqHKesees4N6WF49YUSIX2FrF7S0/edit?tab=t.0#heading=h.hs6r9d26w1y2\" class=\"pastedDriveLink-0\">https://docs.google.com/document/d/1N6a2IOzC6Qsqv7NBqHKesees4N6WF49YUSIX2FrF7S0/edit?tab=t.0#heading=h.hs6r9d26w1y2</a>\n\nJoin with Google Meet: https://meet.google.com/njx-cnib-jyd\n\nLearn more about Meet at: https://support.google.com/a/users/answer/9282720",
       "calendar": "Iceberg Dev Events",
-      "start": "2026-04-13T17:00:00+00:00",
-      "end": "2026-04-13T18:00:00+00:00",
+      "start": "2026-04-13T16:00:00+00:00",
+      "end": "2026-04-13T17:00:00+00:00",
       "recurring": true
     },
     {
@@ -98,9 +89,18 @@
       "location": "",
       "description": "<br>Agenda and notes: <a href=\"https://docs.google.com/document/d/1iGNydKY7XT1N5Nz056vDPM0P8v0MFymGqNtOlUGUp-c/edit?tab=t.0\" class=\"pastedDriveLink-0\">https://docs.google.com/document/d/1iGNydKY7XT1N5Nz056vDPM0P8v0MFymGqNtOlUGUp-c/edit?tab=t.0</a>\n\nJoin with Google Meet: https://meet.google.com/gwy-jxos-jif\n\nLearn more about Meet at: https://support.google.com/a/users/answer/9282720",
       "calendar": "Iceberg Dev Events",
-      "start": "2026-04-14T17:00:00+00:00",
-      "end": "2026-04-14T18:00:00+00:00",
+      "start": "2026-04-14T16:00:00+00:00",
+      "end": "2026-04-14T17:00:00+00:00",
       "recurring": true
+    },
+    {
+      "title": "Iceberg Catalog Community Sync Meeting",
+      "location": "",
+      "description": "Google Meeting Link: <a href=\"https://meet.google.com/xbs-yqfb-joa\">https://meet.google.com/xbs-yqfb-joa</a><br><br>Iceberg meetings for anyone wanting to discuss Iceberg catalog related topics. <br><br>A few things worth noting:<ul><li>The meeting has a <a href=\"https://docs.google.com/document/d/1iPGVCIcr-M0XtAiudOguWAvmqIdVgpYN5vz5ohO8PKw/edit?tab=t.0\" target=\"_blank\"><u>meeting note</u></a></li><li>Previous recordings can be found in the following youtube channel: <a href=\"https://www.youtub",
+      "calendar": "Iceberg Dev Events",
+      "start": "2026-04-15T16:00:00+00:00",
+      "end": "2026-04-15T17:00:00+00:00",
+      "recurring": false
     },
     {
       "title": "Iceberg Rust Community Sync",
@@ -116,8 +116,8 @@
       "location": "",
       "description": "<a href=\"https://docs.google.com/document/d/19nno1RoPznbbxKOZZddZNHHafa7XULjbN6RPExdr2n4/edit?tab=t.0\" class=\"pastedDriveLink-1\">Iceberg - Spark Community Sync Notes</a><br><br>devlist thread: <a href=\"https://lists.apache.org/thread/6m2zo5sj470c00l26gn8cfbm0bc7ooq5\">https://lists.apache.org/thread/6m2zo5sj470c00l26gn8cfbm0bc7ooq5</a>\n\nJoin with Google Meet: https://meet.google.com/aqg-mdpq-myf\n\nLearn more about Meet at: https://support.google.com/a/users/answer/9282720",
       "calendar": "Iceberg Dev Events",
-      "start": "2026-04-21T18:00:00+00:00",
-      "end": "2026-04-21T19:00:00+00:00",
+      "start": "2026-04-21T17:00:00+00:00",
+      "end": "2026-04-21T18:00:00+00:00",
       "recurring": true
     },
     {
@@ -134,8 +134,8 @@
       "location": "",
       "description": "<br>Design doc: <a href=\"https://docs.google.com/document/d/1N6a2IOzC6Qsqv7NBqHKesees4N6WF49YUSIX2FrF7S0/edit?tab=t.0#heading=h.hs6r9d26w1y2\" class=\"pastedDriveLink-0\">https://docs.google.com/document/d/1N6a2IOzC6Qsqv7NBqHKesees4N6WF49YUSIX2FrF7S0/edit?tab=t.0#heading=h.hs6r9d26w1y2</a>\n\nJoin with Google Meet: https://meet.google.com/njx-cnib-jyd\n\nLearn more about Meet at: https://support.google.com/a/users/answer/9282720",
       "calendar": "Iceberg Dev Events",
-      "start": "2026-04-27T17:00:00+00:00",
-      "end": "2026-04-27T18:00:00+00:00",
+      "start": "2026-04-27T16:00:00+00:00",
+      "end": "2026-04-27T17:00:00+00:00",
       "recurring": true
     },
     {
@@ -145,16 +145,25 @@
       "calendar": "Iceberg Dev Events",
       "start": "2026-04-28T16:00:00+00:00",
       "end": "2026-04-28T17:00:00+00:00",
-      "recurring": false
+      "recurring": true
     },
     {
       "title": "Iceberg Read Restrictions Sync",
       "location": "",
       "description": "<br>Agenda and notes: <a href=\"https://docs.google.com/document/d/1iGNydKY7XT1N5Nz056vDPM0P8v0MFymGqNtOlUGUp-c/edit?tab=t.0\" class=\"pastedDriveLink-0\">https://docs.google.com/document/d/1iGNydKY7XT1N5Nz056vDPM0P8v0MFymGqNtOlUGUp-c/edit?tab=t.0</a>\n\nJoin with Google Meet: https://meet.google.com/gwy-jxos-jif\n\nLearn more about Meet at: https://support.google.com/a/users/answer/9282720",
       "calendar": "Iceberg Dev Events",
-      "start": "2026-04-28T17:00:00+00:00",
-      "end": "2026-04-28T18:00:00+00:00",
+      "start": "2026-04-28T16:00:00+00:00",
+      "end": "2026-04-28T17:00:00+00:00",
       "recurring": true
+    },
+    {
+      "title": "Iceberg Catalog Community Sync Meeting",
+      "location": "",
+      "description": "Google Meeting Link: <a href=\"https://meet.google.com/xbs-yqfb-joa\">https://meet.google.com/xbs-yqfb-joa</a><br><br>Iceberg meetings for anyone wanting to discuss Iceberg catalog related topics. <br><br>A few things worth noting:<ul><li>The meeting has a <a href=\"https://docs.google.com/document/d/1iPGVCIcr-M0XtAiudOguWAvmqIdVgpYN5vz5ohO8PKw/edit?tab=t.0\" target=\"_blank\"><u>meeting note</u></a></li><li>Previous recordings can be found in the following youtube channel: <a href=\"https://www.youtub",
+      "calendar": "Iceberg Dev Events",
+      "start": "2026-04-29T16:00:00+00:00",
+      "end": "2026-04-29T17:00:00+00:00",
+      "recurring": false
     }
   ]
 }

--- a/frontend/src/components/EventsView.jsx
+++ b/frontend/src/components/EventsView.jsx
@@ -1,10 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
 import { fetchEvents } from "../lib/data";
-
-function parseDate(s) {
-  const d = new Date(s);
-  return Number.isNaN(d.getTime()) ? null : d;
-}
+import {
+  formatEventLocalTimeRange,
+  formatEventWeekdayDate,
+  localTimeHint,
+  parseEventInstant,
+} from "../lib/eventTime";
 
 function calendarTextBlob(location, description) {
   const raw = `${location || ""} ${description || ""}`;
@@ -44,17 +45,12 @@ function extractEventActionLink(location, description) {
 }
 
 function EventRow({ ev }) {
-  const start = parseDate(ev.start);
-  const end = ev.end ? parseDate(ev.end) : null;
+  const start = parseEventInstant(ev.start);
+  const end = ev.end ? parseEventInstant(ev.end) : null;
   const action = extractEventActionLink(ev.location, ev.description);
 
-  const dateStr = start
-    ? start.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" })
-    : "Unknown date";
-  const timeStr = start
-    ? start.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" })
-    : "";
-  const endStr = end ? end.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" }) : null;
+  const dateStr = formatEventWeekdayDate(start);
+  const { timeRange, zoneShort } = formatEventLocalTimeRange(start, end);
 
   return (
     <div className="bg-white/90 dark:bg-gray-900/90 border border-gray-200/90 dark:border-gray-700 rounded-2xl px-4 py-3 shadow-sm hover:shadow-md transition-shadow">
@@ -69,7 +65,10 @@ function EventRow({ ev }) {
             </span>
           </div>
           <div className="flex flex-wrap items-center gap-x-2 gap-y-1 mt-1 text-xs text-gray-500 dark:text-gray-400">
-            <span className="tabular-nums">{timeStr}{endStr ? `–${endStr}` : ""}</span>
+            <span className="tabular-nums">
+              {timeRange}
+              {zoneShort ? <span className="text-gray-400 dark:text-gray-500"> · {zoneShort}</span> : null}
+            </span>
             {ev.calendar && <span>· {ev.calendar}</span>}
             {ev.recurring && <span className="text-indigo-600 dark:text-indigo-300">· recurring</span>}
           </div>
@@ -109,7 +108,7 @@ export default function EventsView({ projectId }) {
   const events = useMemo(() => {
     const now = Date.now();
     const list = (data?.events || [])
-      .map((ev) => ({ ...ev, _ts: parseDate(ev.start)?.getTime() ?? 0 }))
+      .map((ev) => ({ ...ev, _ts: parseEventInstant(ev.start)?.getTime() ?? 0 }))
       .filter((ev) => ev._ts && ev._ts >= now - 60_000) // tolerate 1m clock drift
       .sort((a, b) => a._ts - b._ts);
     return list;
@@ -126,6 +125,9 @@ export default function EventsView({ projectId }) {
           <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Upcoming events</h2>
           <p className="text-xs text-gray-400 dark:text-gray-500">
             Showing {events.length} event{events.length !== 1 ? "s" : ""} in the next window.
+            <span className="block mt-0.5 text-gray-400/90 dark:text-gray-500/90">
+              Times in your local timezone ({localTimeHint()}).
+            </span>
           </p>
         </div>
         {calendars.length > 0 && (

--- a/frontend/src/components/HomeView.jsx
+++ b/frontend/src/components/HomeView.jsx
@@ -8,6 +8,11 @@
 
 import { useState, useEffect, useMemo } from "react";
 import { fetchInitiatives, fetchEvents, getItemType, relativeTime, SOURCE_META, trendScore } from "../lib/data";
+import {
+  formatEventLocalTimeRange,
+  formatEventMonthDayLocal,
+  parseEventInstant,
+} from "../lib/eventTime";
 import { cleanTitle } from "../lib/utils";
 import DigestBanner from "./DigestBanner";
 import InitiativeDetail from "./InitiativeDetail";
@@ -306,16 +311,19 @@ export default function HomeView({ project, proposals, onSelect, onViewActivity,
                 </div>
                 <div className="space-y-1.5">
                   {upcomingEvents.slice(0, 5).map((ev, i) => {
-                    const start = new Date(ev.start);
+                    const start = parseEventInstant(ev.start);
+                    const end = ev.end ? parseEventInstant(ev.end) : null;
                     const action = extractEventActionLink(ev.location, ev.description);
+                    const { timeRange, zoneShort } = formatEventLocalTimeRange(start, end);
                     return (
                       <div key={i} className="flex items-center justify-between gap-2">
                         <div className="min-w-0">
                           <p className="text-xs font-medium text-gray-800 dark:text-gray-200 truncate">{ev.title}</p>
                           <p className="text-xs text-gray-400 dark:text-gray-500">
-                            {start.toLocaleDateString(undefined, { month: "short", day: "numeric" })}
+                            {formatEventMonthDayLocal(start)}
                             {" · "}
-                            {start.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" })}
+                            {timeRange}
+                            {zoneShort ? ` ${zoneShort}` : ""}
                           </p>
                         </div>
                         {action && (

--- a/frontend/src/lib/eventTime.js
+++ b/frontend/src/lib/eventTime.js
@@ -1,0 +1,93 @@
+/**
+ * Calendar event times from the API are UTC ISO strings.
+ * All display uses the viewer's local timezone explicitly so behavior is
+ * consistent across browsers and it's obvious we're not showing UTC.
+ */
+
+/** @returns {string|undefined} IANA zone, e.g. "America/New_York" */
+export function getViewerTimeZone() {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** @param {string|undefined} iso */
+export function parseEventInstant(iso) {
+  if (!iso) return null;
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+const tz = () => getViewerTimeZone();
+
+/**
+ * @param {Date} date
+ * @param {Intl.DateTimeFormatOptions} base
+ */
+function withLocalZone(base) {
+  const z = tz();
+  return z ? { ...base, timeZone: z } : base;
+}
+
+/** @param {Date|null} date */
+export function formatEventWeekdayDate(date, locale) {
+  if (!date) return "Unknown date";
+  return date.toLocaleDateString(
+    locale,
+    withLocalZone({
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+    })
+  );
+}
+
+/** Compact date for tight layouts (e.g. home sidebar): "Mar 30" in local TZ */
+export function formatEventMonthDayLocal(date, locale) {
+  if (!date) return "";
+  return date.toLocaleDateString(
+    locale,
+    withLocalZone({ month: "short", day: "numeric" })
+  );
+}
+
+/** Short timezone label for one instant, e.g. "GMT+2" or "PST" */
+export function formatTimeZoneShort(date, locale) {
+  if (!date) return "";
+  const parts = new Intl.DateTimeFormat(locale, {
+    ...withLocalZone({ timeZoneName: "short" }),
+    hour: "numeric",
+    minute: "numeric",
+  }).formatToParts(date);
+  return parts.find((p) => p.type === "timeZoneName")?.value ?? "";
+}
+
+/**
+ * @param {Date|null} start
+ * @param {Date|null} end
+ * @returns {{ timeRange: string, zoneShort: string }}
+ */
+export function formatEventLocalTimeRange(start, end, locale) {
+  if (!start) return { timeRange: "", zoneShort: "" };
+  const timeOpts = withLocalZone({ hour: "2-digit", minute: "2-digit" });
+  const a = start.toLocaleTimeString(locale, timeOpts);
+  if (end && !Number.isNaN(end.getTime())) {
+    const b = end.toLocaleTimeString(locale, timeOpts);
+    return {
+      timeRange: `${a}–${b}`,
+      zoneShort: formatTimeZoneShort(start, locale),
+    };
+  }
+  return {
+    timeRange: a,
+    zoneShort: formatTimeZoneShort(start, locale),
+  };
+}
+
+/** One-line hint for list headers, e.g. "America/Los_Angeles" */
+export function localTimeHint() {
+  const z = getViewerTimeZone();
+  return z ? z.replace(/_/g, " ") : "local time";
+}

--- a/scripts/crawl.py
+++ b/scripts/crawl.py
@@ -20,6 +20,7 @@ Usage:
   python scripts/crawl.py --project iceberg --no-llm  # stage-1 local only (skip API LLM stage 2)
   python scripts/crawl.py --project iceberg --reset   # ignore checkpoint; full source pull
   python scripts/crawl.py --project iceberg --re-enrich  # re-run LLM on existing data (no re-crawl)
+  python scripts/crawl.py --project iceberg --only calendar   # ICS calendars → data/<id>/events.json only
   python scripts/generate_digest.py --project iceberg  # digest only (needs LLM key for narrative)
 
 Environment variables:
@@ -687,12 +688,30 @@ def main():
         action="store_true",
         help="Re-run LLM enrichment on existing proposals without re-crawling sources (useful to upgrade quality or switch models)",
     )
+    parser.add_argument(
+        "--only",
+        choices=["calendar"],
+        metavar="SOURCE",
+        help="Run only this source (no GitHub, list, LLM, etc.). Requires calendars in projects/<id>.yaml",
+    )
     args = parser.parse_args()
+
+    if args.only and args.re_enrich:
+        parser.error("--only cannot be used with --re-enrich")
 
     project_ids = [args.project] if args.project else list_project_ids()
     if not project_ids:
         logger.error("No projects found in projects/")
         sys.exit(1)
+
+    if args.only:
+        from crawlers import calendar_crawler
+
+        for pid in project_ids:
+            config = load_project_config(pid)
+            logger.info(f"=== Calendar-only: {pid} ===")
+            calendar_crawler.crawl_events(config, pid)
+        return
 
     for pid in project_ids:
         if args.re_enrich:


### PR DESCRIPTION
Expand recurring events using timezone-aware DTSTART before converting occurrences to UTC, so weekly rules match Google Calendar across DST.

Add explicit local-time formatting and timezone hints on the events page and home upcoming-events strip.

Add `--only calendar` to scripts/crawl.py to refresh events.json without running other sources.

Regenerate data/iceberg/events.json from the fixed crawler.

Made-with: Cursor